### PR TITLE
Fixed a crash when using http or https URLs

### DIFF
--- a/linereader.js
+++ b/linereader.js
@@ -22,13 +22,13 @@ if (typeof setImmediate === 'undefined') {
   var setImmediate = process.nextTick;
 }
 
-var urlPrefix = /^https?:\/\//i;
+var urlProtocolRegex = /^(https?):\/\//i
 
 var LineReader = function (filepath, options) {
   var self = this;
   options = options || {};
 
-  this._filepath = urlPrefix.test(filepath) ? filepath : path.normalize(filepath);
+  this._filepath = urlProtocolRegex.test(filepath) ? filepath : path.normalize(filepath);
   this._encoding = (options.encoding && iconv.encodingExists(options.encoding)) ? options.encoding : 'utf8';
   this._skipEmptyLines = options.skipEmptyLines || false;
   this._readStream = null;
@@ -50,8 +50,7 @@ util.inherits(LineReader, events.EventEmitter);
 LineReader.prototype._initStream = function () {
   var self = this;
 
-  if (urlPrefix.test(self._filepath)) {
-    var urlProtocolRegex = /^(https?):\/\//i
+  if (urlProtocolRegex.test(self._filepath)) {
     var module = urlProtocolRegex.exec(self._filepath)[1].toLowerCase() // http or https
 
     require(module).get(self._filepath, function (res) {

--- a/linereader.js
+++ b/linereader.js
@@ -52,7 +52,6 @@ LineReader.prototype._initStream = function () {
 
   if (urlProtocolRegex.test(self._filepath)) {
     var module = urlProtocolRegex.exec(self._filepath)[1].toLowerCase() // http or https
-
     require(module).get(self._filepath, function (res) {
       self._readStream = res;
       _initStream();

--- a/linereader.js
+++ b/linereader.js
@@ -51,8 +51,10 @@ LineReader.prototype._initStream = function () {
   var self = this;
 
   if (urlPrefix.test(self._filepath)) {
-    var protocol = urlPrefix.exec(self._filepath);
-    require(protocol[0].toLowerCase().substring(0,protocol[0].indexOf(":"))).get(self._filepath, function (res) {
+    var urlProtocolRegex = /^(https?):\/\//i
+    var module = urlProtocolRegex.exec(self._filepath)[1].toLowerCase() // http or https
+
+    require(module).get(self._filepath, function (res) {
       self._readStream = res;
       _initStream();
     }).on('error', function(err) {

--- a/linereader.js
+++ b/linereader.js
@@ -52,7 +52,7 @@ LineReader.prototype._initStream = function () {
 
   if (urlPrefix.test(self._filepath)) {
     var protocol = urlPrefix.exec(self._filepath);
-    require(protocol[0].toLowerCase()).get(self._filepath, function (res) {
+    require(protocol[0].toLowerCase().substring(0,protocol[0].indexOf(":"))).get(self._filepath, function (res) {
       self._readStream = res;
       _initStream();
     }).on('error', function(err) {


### PR DESCRIPTION
The problem was caused by an incorrect way of getting the module name from the URL protocol. The exception log was:

module.js:339
    throw err;
    ^

Error: Cannot find module 'https://'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at LineReader._initStream (./linereader.js:55:5)
    at ./linereader.js:44:10
    at doNTCallback0 (node.js:419:9)
    at process._tickCallback (node.js:348:13)
